### PR TITLE
skill: note global naming and non-interactive shell gotchas

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -28,6 +28,10 @@ scp file.txt <vm>.exe.xyz:~/ # transfer file
 
 Every VM gets `https://<vm>.exe.xyz/` with automatic TLS.
 
+## Naming
+
+VM names are globally unique across all exe.dev customers. If `new --name=<n>` errors with `"this VM name is not available"`, the slug is taken (by you or someone else) — pick another. Generic names like `app`, `staging`, `demo` are mostly gone; add a suffix (`<purpose>-<yyyymmdd>` or a short random) for any new VM you intend to keep.
+
 ## A tale of two SSH destinations
 
 - **`ssh exe.dev <command>`** — the exe.dev lobby. A REPL for VM lifecycle, sharing, and configuration. Does not support scp, sftp, or arbitrary shell commands.
@@ -48,3 +52,17 @@ Host exe.dev *.exe.xyz
   IdentitiesOnly yes
   IdentityFile ~/.ssh/id_ed25519
 ```
+
+**Multi-line commands**: Heredocs and embedded newlines collapse when passed inside a quoted argument to `ssh <vm>.exe.xyz "<cmd>"` from many shells (`\n` flattens to spaces, breaking scripts). Feed multi-line scripts via `bash -s` over stdin instead:
+
+```
+ssh <vm>.exe.xyz 'bash -s' <<'EOF'
+set -e
+sudo apt-get update
+# ...
+EOF
+```
+
+For non-text content (binaries, anything sensitive to whitespace), base64-encode locally and decode on the VM.
+
+**Lobby-routed VM shell**: `ssh exe.dev ssh <vm> "<cmd>"` runs a shell command on the VM via the lobby. Convenient in non-interactive scripts — the lobby's host key is already trusted, so there's no per-VM `known_hosts` setup or `accept-new` prompt. (No scp/sftp through this path; use direct `<vm>.exe.xyz` for transfers.)


### PR DESCRIPTION
## Summary

Two small additions to `skill/SKILL.md`, both motivated by getting an agent productive against exe.dev for the first time:

- **New "Naming" section.** VM names are globally unique across customers. The first time an agent picks a generic slug (`app-test`, `demo-1`, etc.) and sees the `"this VM name is not available"` error, it has no way to know whether it collided with one of its own VMs or someone else's. Three lines of skill text save a confused round-trip.

- **Two extensions to "Working in non-interactive and sandboxed environments":**
  - **Multi-line commands**: heredocs collapse to single-line strings when passed as a quoted argument to `ssh <vm>.exe.xyz "<cmd>"` from many shells. The fix is `bash -s` over stdin (or base64 transport for binaries / whitespace-sensitive payloads). Hit this multiple times when provisioning a VM via an agent harness.
  - **Lobby-routed VM shell**: `ssh exe.dev ssh <vm> "<cmd>"` is a useful escape hatch for non-interactive scripts — the lobby's host key is already trusted, so there's no per-VM `known_hosts` plumbing or `accept-new` prompt. It's already documented in `ssh exe.dev help`, but pulling it forward into the skill (alongside the existing `accept-new` advice) makes it discoverable for agents that read the skill but not the help.

Tone matches the existing skill (terse, no list-of-pitfalls, brief explanation of the why).

## Diff

+18 lines, 0 deletions. No changes outside `skill/SKILL.md`.

## Test plan

- [x] Verified all three additions against the live `ssh exe.dev` CLI (Trial plan).
- [x] Re-read the diff against the existing skill voice — additions slot into the current section structure without restructuring it.